### PR TITLE
Fix: IterationSelector filter overflow

### DIFF
--- a/src/public/components/IterationSelector.jsx
+++ b/src/public/components/IterationSelector.jsx
@@ -175,6 +175,7 @@ const IterationState = styled.span`
 /**
  * Unified controls bar containing search and filters
  * Horizontal layout with consistent spacing and visual treatment
+ * Wraps to prevent overflow
  * @component
  */
 const ControlsBar = styled.div`
@@ -186,6 +187,7 @@ const ControlsBar = styled.div`
   border: 1px solid var(--border);
   border-radius: 8px;
   margin: 1rem;
+  flex-wrap: wrap;
 
   /* Mobile: Stack vertically */
   @media (max-width: 640px) {
@@ -257,7 +259,8 @@ const FilterSelect = styled.select`
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M6 9L1 4h10z'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 0.5rem center;
-  min-width: 140px;
+  min-width: 120px;
+  max-width: 160px;
 
   &:focus {
     outline: none;
@@ -272,6 +275,7 @@ const FilterSelect = styled.select`
   @media (max-width: 640px) {
     flex: 1;
     min-width: 0;
+    max-width: none;
   }
 `;
 


### PR DESCRIPTION
## Summary
Fixes overflow issue where the Cadence filter dropdown was extending past the right border of the ControlsBar container.

## Changes
- Added `flex-wrap: wrap` to ControlsBar to allow controls to wrap when needed
- Reduced FilterSelect min-width from 140px to 120px
- Added max-width: 160px to FilterSelect to constrain size
- Maintained responsive behavior on mobile devices

## Testing
- ✅ All 13 IterationSelector tests pass
- ✅ Verified controls no longer overflow container
- ✅ Responsive behavior maintained on mobile

## Screenshots
**Before:** Cadence filter extended past container border
**After:** All controls stay within container bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)