### PR TITLE
Fix: Display iteration end dates in velocity chart

### DIFF
--- a/src/lib/infrastructure/adapters/GitLabIterationDataProvider.js
+++ b/src/lib/infrastructure/adapters/GitLabIterationDataProvider.js
@@ -36,11 +36,12 @@ export class GitLabIterationDataProvider extends IIterationDataProvider {
    */
   async fetchIterationData(iterationId) {
     try {
-      // Fetch iteration details (includes issues and iteration metadata)
-      const iterationDetails = await this.gitlabClient.fetchIterationDetails(iterationId);
+      // Fetch iteration list to get metadata (includes dates)
+      const iterations = await this.gitlabClient.fetchIterations();
+      const iterationMetadata = iterations.find(it => it.id === iterationId);
 
-      // Extract iteration metadata from GitLab response
-      const iteration = iterationDetails.iteration || {};
+      // Fetch iteration details (includes issues)
+      const iterationDetails = await this.gitlabClient.fetchIterationDetails(iterationId);
 
       // For now, return basic structure
       // TODO: Fetch additional data (MRs, pipelines, incidents) in future stories
@@ -50,10 +51,10 @@ export class GitLabIterationDataProvider extends IIterationDataProvider {
         pipelines: [], // TODO: Implement pipeline fetching
         incidents: [], // TODO: Implement incident fetching
         iteration: {
-          id: iteration.id || iterationId,
-          title: iteration.title || 'Unknown Sprint',
-          startDate: iteration.startDate || new Date().toISOString(),
-          dueDate: iteration.dueDate || new Date().toISOString(),
+          id: iterationMetadata?.id || iterationId,
+          title: iterationMetadata?.title || 'Unknown Sprint',
+          startDate: iterationMetadata?.startDate || new Date().toISOString(),
+          dueDate: iterationMetadata?.dueDate || new Date().toISOString(),
         },
       };
     } catch (error) {

--- a/src/public/components/VelocityChart.jsx
+++ b/src/public/components/VelocityChart.jsx
@@ -102,17 +102,13 @@ const VelocityChart = ({ iterationIds }) => {
   }, [iterationIds]);
 
   /**
-   * Format date to short format (e.g., "Nov 9, 2025")
+   * Format date to short MM/DD format (e.g., "8/3")
    * @param {string} dateString - ISO date string
    * @returns {string} Formatted date string
    */
   const formatDate = (dateString) => {
     const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric'
-    });
+    return `${date.getMonth() + 1}/${date.getDate()}`;
   };
 
   /**

--- a/test/public/components/VelocityChart.test.jsx
+++ b/test/public/components/VelocityChart.test.jsx
@@ -98,8 +98,8 @@ describe('VelocityChart', () => {
     const chartElement = screen.getByTestId('velocity-chart');
     const chartData = JSON.parse(chartElement.getAttribute('data-chart-data'));
 
-    // Verify chart labels use formatted due dates
-    expect(chartData.labels).toEqual(['Jan 13, 2025', 'Jan 27, 2025']);
+    // Verify chart labels use formatted due dates in MM/DD format
+    expect(chartData.labels).toEqual(['1/13', '1/27']);
 
     // Verify datasets for story points and story count
     expect(chartData.datasets).toHaveLength(2);


### PR DESCRIPTION
## Summary
Fixes two issues with velocity chart labels:
1. All iterations were showing the same date (today's date)
2. Date format was too long

## Root Cause
The backend `GitLabIterationDataProvider` was not fetching iteration metadata (title, dates) because `fetchIterationDetails()` only returns issues. This caused it to fall back to `new Date()` for all iterations, resulting in today's date for every data point.

## Changes

**Backend:**
- Fixed `GitLabIterationDataProvider.fetchIterationData()` to fetch iteration list and extract metadata
- Now properly retrieves actual `startDate` and `dueDate` from GitLab for each iteration

**Frontend:**
- Changed date format from "Nov 9, 2025" to "8/3" (MM/DD format)
- Updated `VelocityChart.formatDate()` to use `${month + 1}/${day}` format

**Tests:**
- Updated test expectations to match new MM/DD format
- All 5 VelocityChart tests pass

## Testing
- ✅ All 5 VelocityChart tests pass
- ✅ Chart now displays different dates for each iteration (e.g., "8/3", "8/10", "8/17")
- ✅ Date format is concise (MM/DD instead of "Month Day, Year")
- ✅ Backend API returns correct iteration dates from GitLab

## Before/After
**Before:** 
- Chart showed "Unknown Sprint" OR all same date "11/9" for all iterations
- Date format was verbose: "Nov 9, 2025"

**After:** 
- Chart shows correct iteration end dates in MM/DD format (e.g., "8/3", "8/10", "8/17")
- Each iteration has its actual due date from GitLab

🤖 Generated with [Claude Code](https://claude.com/claude-code)