### PR TITLE
fix: improve 'Change Sprints' behavior and cached badge visibility

### DIFF
--- a/src/public/components/IterationSelectionModal.jsx
+++ b/src/public/components/IterationSelectionModal.jsx
@@ -310,7 +310,9 @@ export default function IterationSelectionModal({
         try {
           const response = await fetch('/api/cache/status');
           const data = await response.json();
-          setCachedIterationIds(new Set(data.cachedIterations || []));
+          // Extract iteration IDs from the iterations array
+          const cachedIds = (data.iterations || []).map(iter => iter.iterationId);
+          setCachedIterationIds(new Set(cachedIds));
         } catch (error) {
           console.error('Failed to fetch cache status:', error);
           setCachedIterationIds(new Set());

--- a/src/public/components/IterationSelector.jsx
+++ b/src/public/components/IterationSelector.jsx
@@ -114,7 +114,7 @@ const IterationSelector = ({
   }, [propCachedIterationIds]);
 
   // Use Select All hook for Select All checkbox functionality
-  const { selectAllRef, handleSelectAll } = useSelectAll(
+  const { selectAllRef, isChecked, isIndeterminate, handleSelectAll } = useSelectAll(
     filteredIterations,
     selectedIds,
     setSelectedIds
@@ -192,6 +192,7 @@ const IterationSelector = ({
             <input
               ref={selectAllRef}
               type="checkbox"
+              checked={isChecked}
               onChange={(e) => handleSelectAll(e.target.checked)}
               aria-label="Select All"
             />
@@ -256,11 +257,14 @@ const IterationSelector = ({
           const isChecked = selectedIds.includes(iteration.id);
           const downloadState = downloadStates[iteration.id];
 
-          // Determine download badge status (only show for checked iterations - Option A)
+          // Determine download badge status
           const getDownloadStatus = () => {
-            if (!isChecked) return null; // Don't show badge on unchecked iterations
-
+            // Always show cached badge if iteration is cached
             if (isCached) return 'cached';
+
+            // Only show download progress badges on checked iterations
+            if (!isChecked) return null;
+
             if (!downloadState) return 'not-downloaded';
             if (downloadState.status === 'downloading') return 'downloading';
             if (downloadState.status === 'complete') return 'cached';

--- a/src/public/components/VelocityApp.jsx
+++ b/src/public/components/VelocityApp.jsx
@@ -169,8 +169,11 @@ export default function VelocityApp() {
 
   /**
    * Handle opening the iteration selection modal
+   * Clears graphs and selections to start fresh
    */
   const handleOpenModal = () => {
+    // Clear all selections when opening modal (graphs will clear automatically)
+    setSelectedIterations([]);
     setIsModalOpen(true);
   };
 

--- a/test/public/components/IterationSelectionModal.test.jsx
+++ b/test/public/components/IterationSelectionModal.test.jsx
@@ -443,11 +443,13 @@ describe('IterationSelectionModal', () => {
         return fetchPromise;
       }
       if (url.includes('/api/cache/status')) {
-        // Simulate some iterations are already cached
+        // Simulate some iterations are already cached (match real API format)
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({
-            cachedIterations: ['gid://gitlab/Iteration/1']
+            iterations: [
+              { iterationId: 'gid://gitlab/Iteration/1', status: 'cached' }
+            ]
           })
         });
       }

--- a/test/public/hooks/useSelectAll.test.js
+++ b/test/public/hooks/useSelectAll.test.js
@@ -173,12 +173,14 @@ describe('useSelectAll', () => {
 
     // Start with none selected
     rerender({ selectedIds: [] });
-    expect(mockCheckboxRef.checked).toBe(false);
+    expect(result.current.isChecked).toBe(false);
+    expect(result.current.isIndeterminate).toBe(false);
     expect(mockCheckboxRef.indeterminate).toBe(false);
 
     // Select one
     rerender({ selectedIds: ['gid://gitlab/Iteration/1'] });
-    expect(mockCheckboxRef.checked).toBe(false);
+    expect(result.current.isChecked).toBe(false);
+    expect(result.current.isIndeterminate).toBe(true);
     expect(mockCheckboxRef.indeterminate).toBe(true);
 
     // Select all
@@ -189,7 +191,8 @@ describe('useSelectAll', () => {
         'gid://gitlab/Iteration/3'
       ]
     });
-    expect(mockCheckboxRef.checked).toBe(true);
+    expect(result.current.isChecked).toBe(true);
+    expect(result.current.isIndeterminate).toBe(false);
     expect(mockCheckboxRef.indeterminate).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Fixes multiple UX issues with the iteration selection modal to improve user experience when changing sprint selections.

## Issues Fixed

1. **Graphs and selections not clearing** - Clicking "Change Sprints" now clears all graphs and selections, giving users a fresh start
2. **"Select All" checkbox state** - Fixed checkbox staying checked when it should be unchecked
3. **Cached badge visibility** - Cached badges now show on all cached iterations (not just checked ones)
4. **API response parsing** - Fixed cache status API response parsing bug

## Changes

### 1. Clear graphs when "Change Sprints" clicked
**File:** `src/public/components/VelocityApp.jsx`
- `handleOpenModal()` now resets `selectedIterations` to `[]` before opening modal
- All graphs clear immediately when user clicks "Change Sprints"
- Modal opens with no iterations selected (clean slate)

### 2. Fix "Select All" checkbox state
**Files:** `src/public/hooks/useSelectAll.js`, `src/public/components/IterationSelector.jsx`
- Refactored `useSelectAll` hook to use controlled checkbox pattern
- Returns computed `isChecked` and `isIndeterminate` values
- Checkbox now has `checked` prop instead of imperative ref updates
- Eliminates timing issues and ensures correct state on modal open

### 3. Show cached badges on all iterations
**File:** `src/public/components/IterationSelector.jsx`
- Cached badges (green "✓ Cached") now visible on ALL cached iterations
- Download progress badges (downloading/not-downloaded/failed) only show on checked iterations
- Helps users see what data is available before selecting

### 4. Fix cache status API parsing
**File:** `src/public/components/IterationSelectionModal.jsx`
- Fixed API response parsing to read `data.iterations` (not `data.cachedIterations`)
- Extracts `iterationId` from each iteration object
- Matches actual API response format

## Testing

- ✅ All 399 tests passing
- ✅ Manual verification completed
- ✅ Updated tests to match new behavior:
  - `test/public/hooks/useSelectAll.test.js` - checks computed values
  - `test/public/components/IterationSelectionModal.test.jsx` - uses correct API format

## Current Behavior

After these changes:
- ✅ Click "Change Sprints" → all graphs clear, all selections reset
- ✅ "Select All" checkbox starts unchecked
- ✅ Cached badges show on all cached iterations
- ✅ Download progress badges only show on checked iterations
- ✅ Modal opens with fresh state every time

## Files Changed (6 files, +58/-31 lines)

- `src/public/components/VelocityApp.jsx`
- `src/public/hooks/useSelectAll.js`
- `src/public/components/IterationSelector.jsx`
- `src/public/components/IterationSelectionModal.jsx`
- `test/public/hooks/useSelectAll.test.js`
- `test/public/components/IterationSelectionModal.test.jsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)