### PR TITLE
Phase 1.3b-3: Extract IterationClient, IssueClient, and IncidentClient (#145)

### DIFF
--- a/_context/stories/completed.md
+++ b/_context/stories/completed.md
@@ -28,6 +28,62 @@ Stories are prepended to this file (most recent at top).
 
 ## Stories
 
+## REFACTOR Phase 1.3b-3: Extract IterationClient, IssueClient, and IncidentClient
+
+**Completed:** 2025-12-14
+**GitHub Issue:** #145
+**Pull Request:** TBD
+
+**Goal:** Complete the GitLabClient refactoring by extracting the final 3 clients. Reduce GitLabClient from "God Object" to orchestrator/facade.
+
+**What Was Delivered:**
+1. **IterationClient** (7 unit tests)
+   - Extracted `fetchIterations()` method
+   - Handles pagination and parent group fallback
+   - Uses GraphQLExecutor for consistent error handling
+
+2. **IssueClient** (17 unit tests)
+   - Extracted `fetchAdditionalNotesForIssue()` - paginated note fetching
+   - Extracted `extractInProgressTimestamp()` - status change extraction
+   - Extracted `parseStatusChanges()` - note parsing helper
+   - Extracted `isInProgressStatus()` - status pattern matching
+
+3. **IncidentClient** (15 unit tests)
+   - Extracted `fetchIncidents()` - complex incident fetching with timeline enrichment
+   - Extracted `fetchIncidentTimelineEvents()` - timeline event fetching
+   - Extracted `extractProjectPath()` - URL parsing helper
+   - Includes timeline-based filtering and change link extraction
+   - Dependencies: IncidentAnalyzer, ChangeLinkExtractor, MergeRequestClient
+
+**Results:**
+- **GitLabClient reduced from 1,134 lines to 548 lines** (-586 lines, 52% reduction!)
+- Added 39 new unit tests (total now 946 tests)
+- All tests passing
+- Backward compatibility maintained - public API unchanged
+
+**Architecture:**
+- ✅ Single Responsibility - Each client has focused domain
+- ✅ Dependency Inversion - All clients use GraphQLExecutor
+- ✅ IncidentClient receives MergeRequestClient as dependency (for change date fetching)
+- ✅ Clean separation of concerns with private helper methods
+
+**Phase 1.3 Summary:**
+| Phase | Client | Methods | Tests | Lines Moved |
+|-------|--------|---------|-------|-------------|
+| 1.3a | Core Helpers | 3 (RateLimitManager, ErrorTransformer, GraphQLExecutor) | 10 | ~150 |
+| 1.3b-1 | DeploymentClient | 1 | 5 | ~50 |
+| 1.3b-2 | PipelineClient + MergeRequestClient | 4 | 14 | ~100 |
+| 1.3b-3 | IterationClient + IssueClient + IncidentClient | 7 | 39 | ~400 |
+
+**Total:** GitLabClient reduced from ~1,230 lines to 548 lines (55% reduction)
+
+**Note:** The target was ~150 lines, but 548 is acceptable because:
+- `fetchIterationDetails()` remains complex orchestration logic (~250 lines)
+- Removing this would require deeper restructuring
+- The extracted clients follow SRP and are well-tested
+
+---
+
 ## REFACTOR Phase 1.3b-2: Extract PipelineClient and MergeRequestClient
 
 **Completed:** 2025-12-04

--- a/src/lib/infrastructure/api/clients/IncidentClient.js
+++ b/src/lib/infrastructure/api/clients/IncidentClient.js
@@ -1,0 +1,511 @@
+/**
+ * Client for fetching GitLab incident data.
+ * Handles incident queries, timeline events, and change link resolution.
+ *
+ * @module IncidentClient
+ */
+
+import { IncidentAnalyzer } from '../../../core/services/IncidentAnalyzer.js';
+import { ChangeLinkExtractor } from '../../../core/services/ChangeLinkExtractor.js';
+
+/**
+ * Client responsible for fetching incident-related data from GitLab.
+ * Includes timeline event fetching and incident filtering logic.
+ */
+export class IncidentClient {
+  /**
+   * Creates a new IncidentClient instance.
+   *
+   * @param {import('../core/GraphQLExecutor.js').GraphQLExecutor} executor - GraphQL executor
+   * @param {import('../core/RateLimitManager.js').RateLimitManager} rateLimitManager - Rate limit manager
+   * @param {string} projectPath - GitLab project path (e.g., 'group/project')
+   * @param {import('./MergeRequestClient.js').MergeRequestClient} mergeRequestClient - MR client for change dates
+   * @param {import('../../../../core/interfaces/ILogger.js').ILogger} [logger] - Logger instance (optional)
+   */
+  constructor(executor, rateLimitManager, projectPath, mergeRequestClient, logger = null) {
+    this.executor = executor;
+    this.rateLimitManager = rateLimitManager;
+    this.projectPath = projectPath;
+    this.mergeRequestClient = mergeRequestClient;
+    this.logger = logger;
+  }
+
+  /**
+   * Extracts project path from incident webUrl.
+   * Example: https://gitlab.com/group/project/-/issues/123 → group/project
+   *
+   * @param {string} webUrl - Incident web URL
+   * @returns {string|null} Project path or null if extraction fails
+   */
+  extractProjectPath(webUrl) {
+    try {
+      const url = new URL(webUrl);
+      const pathParts = url.pathname.split('/-/')[0]; // Get everything before /-/
+      const projectPath = pathParts.substring(1); // Remove leading /
+
+      // Validate that we got a meaningful path
+      if (!projectPath || projectPath.length === 0) {
+        return null;
+      }
+
+      return projectPath;
+    } catch (error) {
+      if (this.logger) {
+        this.logger.error('Error extracting project path from URL', {
+          webUrl,
+          error: error.message
+        });
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Fetches timeline events for a specific incident.
+   * Timeline events contain actual incident timing with tags like "Start time", "End time".
+   *
+   * @param {Object} incident - Incident object with id and webUrl
+   * @param {string} incident.id - GitLab incident ID (e.g., 'gid://gitlab/Issue/123')
+   * @param {string} incident.webUrl - Incident web URL (used to extract project path)
+   * @returns {Promise<Array>} Array of timeline event objects
+   */
+  async fetchIncidentTimelineEvents(incident) {
+    // Extract project path from incident's webUrl
+    const projectPath = this.extractProjectPath(incident.webUrl);
+
+    if (!projectPath) {
+      if (this.logger) {
+        this.logger.error('Could not extract project path from incident webUrl', {
+          incidentWebUrl: incident.webUrl
+        });
+      }
+      return [];
+    }
+
+    const query = `
+      query getIncidentTimelineEvents($fullPath: ID!, $incidentId: IssueID!) {
+        project(fullPath: $fullPath) {
+          incidentManagementTimelineEvents(incidentId: $incidentId) {
+            nodes {
+              id
+              occurredAt
+              createdAt
+              note
+              noteHtml
+              editable
+              action
+              timelineEventTags {
+                nodes {
+                  name
+                }
+              }
+              author {
+                username
+                name
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    try {
+      const data = await this.executor.execute(
+        query,
+        { fullPath: projectPath, incidentId: incident.id },
+        'fetching incident timeline'
+      );
+
+      if (!data.project || !data.project.incidentManagementTimelineEvents) {
+        return [];
+      }
+
+      return data.project.incidentManagementTimelineEvents.nodes;
+    } catch (error) {
+      if (this.logger) {
+        this.logger.error('Error fetching timeline events', {
+          incidentId: incident.id,
+          error: error.message
+        });
+        if (error.response?.errors) {
+          error.response.errors.forEach(err => {
+            this.logger.error('GraphQL error detail', {
+              message: err.message
+            });
+          });
+        }
+      }
+      // Return empty array instead of throwing - timeline events might not be available
+      return [];
+    }
+  }
+
+  /**
+   * Fetches incidents (issues with type=INCIDENT) within a date range.
+   * Returns enriched incident data with timeline metadata for calculations.
+   *
+   * @param {string} startDate - Start date (ISO format or parseable string)
+   * @param {string} endDate - End date (ISO format or parseable string)
+   * @returns {Promise<Array>} Array of enriched incident objects
+   * @throws {Error} If the group is not found or request fails
+   */
+  async fetchIncidents(startDate, endDate) {
+    const query = `
+      query getIncidents($fullPath: ID!, $after: String, $createdAfter: Time, $createdBefore: Time) {
+        group(fullPath: $fullPath) {
+          id
+          issues(
+            types: [INCIDENT]
+            includeSubgroups: true
+            createdAfter: $createdAfter
+            createdBefore: $createdBefore
+            first: 100
+            after: $after
+          ) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              id
+              iid
+              title
+              state
+              createdAt
+              closedAt
+              updatedAt
+              webUrl
+              labels {
+                nodes {
+                  title
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    let allIncidents = [];
+    let hasNextPage = true;
+    let after = null;
+
+    try {
+      // BUG FIX: Fetch broader date range (60 days before iteration start)
+      // to catch incidents created before iteration but active during it
+      const iterationStart = new Date(startDate);
+      const iterationEnd = new Date(endDate);
+      const fetchStart = new Date(iterationStart);
+      fetchStart.setDate(fetchStart.getDate() - 60); // 60 days before iteration
+
+      const createdAfter = fetchStart.toISOString();
+      const createdBefore = iterationEnd.toISOString();
+
+      if (this.logger) {
+        this.logger.debug('Querying incidents from group', {
+          fetchStartDate: fetchStart.toISOString().split('T')[0],
+          fetchEndDate: endDate,
+          iterationStartDate: startDate,
+          iterationEndDate: endDate,
+          lookbackDays: 60
+        });
+      }
+
+      while (hasNextPage) {
+        const data = await this.executor.execute(
+          query,
+          { fullPath: this.projectPath, after, createdAfter, createdBefore },
+          'fetching incidents'
+        );
+
+        if (!data.group) {
+          throw new Error(`Group not found: ${this.projectPath}`);
+        }
+
+        if (!data.group.issues) {
+          break;
+        }
+
+        const { nodes, pageInfo } = data.group.issues;
+        allIncidents = allIncidents.concat(nodes);
+        hasNextPage = pageInfo.hasNextPage;
+        after = pageInfo.endCursor;
+
+        if (hasNextPage) {
+          await this.rateLimitManager.delay(100);
+        }
+      }
+
+      if (this.logger) {
+        this.logger.debug('Fetched incidents from broader date range', {
+          count: allIncidents.length
+        });
+      }
+
+      // TIMELINE-BASED FILTERING: Fetch timeline events for each incident to get actual start times
+      if (this.logger) {
+        this.logger.debug('Fetching timeline events for incidents');
+      }
+      const incidentsWithTimelines = await Promise.all(
+        allIncidents.map(async (incident) => {
+          const timelineEvents = await this.fetchIncidentTimelineEvents(incident);
+          return { incident, timelineEvents };
+        })
+      );
+
+      if (this.logger) {
+        this.logger.debug('Fetched timeline events for incidents', {
+          count: incidentsWithTimelines.length
+        });
+      }
+
+      // Filter to only include incidents with activity during iteration
+      const relevantIncidents = this._filterIncidentsByDateRange(
+        incidentsWithTimelines,
+        iterationStart,
+        iterationEnd
+      );
+
+      if (this.logger) {
+        this.logger.debug('Filtered to incidents with activity during iteration', {
+          count: relevantIncidents.length
+        });
+      }
+
+      // Return raw data WITH timeline metadata for Data Explorer visibility
+      const relevantIncidentsData = relevantIncidents.map(({ incident, timelineEvents }) => {
+        return this._enrichIncidentWithTimeline(incident, timelineEvents);
+      });
+
+      // Fetch change dates for incidents with change links
+      const incidentsWithChangeDates = await this._fetchChangeDates(relevantIncidentsData);
+
+      if (this.logger) {
+        this.logger.debug('Fetched change dates for incidents with change links');
+      }
+
+      return incidentsWithChangeDates;
+    } catch (error) {
+      // Check if it's a GraphQL error
+      if (error.response?.errors) {
+        throw new Error(`Failed to fetch incidents: ${error.response.errors[0].message}`);
+      }
+      throw new Error(`Failed to fetch incidents: ${error.message}`);
+    }
+  }
+
+  /**
+   * Filters incidents to only include those with activity during the iteration.
+   *
+   * @param {Array} incidentsWithTimelines - Array of {incident, timelineEvents}
+   * @param {Date} iterationStart - Iteration start date
+   * @param {Date} iterationEnd - Iteration end date
+   * @returns {Array} Filtered incidents
+   * @private
+   */
+  _filterIncidentsByDateRange(incidentsWithTimelines, iterationStart, iterationEnd) {
+    return incidentsWithTimelines.filter(({ incident, timelineEvents }) => {
+      // Get actual start time using IncidentAnalyzer (cascading fallback: timeline → createdAt)
+      const actualStartTime = IncidentAnalyzer.getActualStartTime(incident, timelineEvents);
+      const startTimeDate = new Date(actualStartTime);
+
+      // Check if we have a timeline start time event (more authoritative than createdAt)
+      const hasTimelineStartTime = timelineEvents && timelineEvents.length > 0 &&
+        IncidentAnalyzer.findTimelineEventByTag(timelineEvents, 'start time') !== null;
+
+      // Check various activity dates
+      const startedDuringIteration = startTimeDate >= iterationStart && startTimeDate <= iterationEnd;
+
+      // If we have a timeline start time event, ONLY use that for filtering
+      if (hasTimelineStartTime) {
+        return startedDuringIteration;
+      }
+
+      // Fallback: If no timeline events, use any activity (closed/updated) for backward compatibility
+      const updated = incident.updatedAt ? new Date(incident.updatedAt) : null;
+      const closed = incident.closedAt ? new Date(incident.closedAt) : null;
+
+      const closedDuringIteration = closed && closed >= iterationStart && closed <= iterationEnd;
+      const updatedDuringIteration = updated && updated >= iterationStart && updated <= iterationEnd;
+
+      // Include incident if it has ANY activity during iteration (backward compatibility)
+      return startedDuringIteration || closedDuringIteration || updatedDuringIteration;
+    });
+  }
+
+  /**
+   * Enriches an incident with timeline metadata.
+   *
+   * @param {Object} incident - Raw incident object
+   * @param {Array} timelineEvents - Timeline events for the incident
+   * @returns {Object} Enriched incident object
+   * @private
+   */
+  _enrichIncidentWithTimeline(incident, timelineEvents) {
+    // Log timeline events for debugging
+    if (this.logger) {
+      this.logger.debug('Processing incident timeline events', {
+        incidentIid: incident.iid,
+        incidentTitle: incident.title,
+        timelineEventsCount: timelineEvents?.length || 0
+      });
+
+      if (timelineEvents && timelineEvents.length > 0) {
+        timelineEvents.forEach((event, idx) => {
+          const tags = event.timelineEventTags?.nodes?.map(t => t.name).join(', ') || 'no tags';
+          this.logger.debug('Timeline event', {
+            incidentIid: incident.iid,
+            eventIndex: idx + 1,
+            occurredAt: event.occurredAt,
+            tags
+          });
+        });
+      }
+    }
+
+    // Determine which timeline events are being used
+    const startEvent = IncidentAnalyzer.findTimelineEventByTag(timelineEvents, 'start time');
+    const endEvent = IncidentAnalyzer.findTimelineEventByTag(timelineEvents, 'end time');
+    const stopEvent = IncidentAnalyzer.findTimelineEventByTag(timelineEvents, 'stop time');
+    const mitigatedEvent = IncidentAnalyzer.findTimelineEventByTag(timelineEvents, 'impact mitigated');
+
+    if (this.logger) {
+      this.logger.debug('Timeline event analysis', {
+        incidentIid: incident.iid,
+        foundStartEvent: !!startEvent,
+        foundEndEvent: !!endEvent,
+        foundStopEvent: !!stopEvent,
+        foundMitigatedEvent: !!mitigatedEvent
+      });
+    }
+
+    // Get actual times used in calculations
+    const actualStartTime = IncidentAnalyzer.getActualStartTime(incident, timelineEvents);
+    const actualEndTime = endEvent?.occurredAt || stopEvent?.occurredAt || mitigatedEvent?.occurredAt || incident.closedAt;
+
+    // Determine sources for Data Explorer display
+    const startTimeSource = startEvent ? 'timeline' : 'created';
+    let endTimeSource = null;
+    if (endEvent) {
+      endTimeSource = 'timeline_end';
+    } else if (stopEvent) {
+      endTimeSource = 'timeline_stop';
+    } else if (mitigatedEvent) {
+      endTimeSource = 'timeline_mitigated';
+    } else if (incident.closedAt) {
+      endTimeSource = 'closed';
+    }
+
+    if (this.logger) {
+      this.logger.debug('Incident time sources', {
+        incidentIid: incident.iid,
+        startTimeSource,
+        endTimeSource,
+        actualStartTime,
+        actualEndTime
+      });
+    }
+
+    // Extract change link (MR or commit) from timeline events for CFR calculation
+    const changeLink = ChangeLinkExtractor.extractFromTimelineEvents(timelineEvents);
+    if (changeLink && this.logger) {
+      this.logger.debug('Found change link for incident', {
+        incidentIid: incident.iid,
+        changeLinkType: changeLink.type,
+        changeLinkUrl: changeLink.url
+      });
+    }
+
+    return {
+      id: incident.id,
+      iid: incident.iid,
+      title: incident.title,
+      state: incident.state,
+      createdAt: incident.createdAt,
+      closedAt: incident.closedAt,
+      updatedAt: incident.updatedAt,
+      labels: incident.labels,
+      webUrl: incident.webUrl,
+      // Timeline metadata for Data Explorer
+      actualStartTime,
+      actualEndTime,
+      startTimeSource,
+      endTimeSource,
+      hasTimelineEvents: timelineEvents && timelineEvents.length > 0,
+      // Timeline events (full data for CFR calculation)
+      timelineEvents: timelineEvents || [],
+      // Extracted change link (MR or commit) for CFR correlation
+      changeLink,
+      // Change date placeholder (will be populated after mapping)
+      changeDate: null,
+    };
+  }
+
+  /**
+   * Fetches change dates for incidents with change links.
+   *
+   * @param {Array} incidents - Enriched incident objects
+   * @returns {Promise<Array>} Incidents with change dates populated
+   * @private
+   */
+  async _fetchChangeDates(incidents) {
+    if (this.logger) {
+      this.logger.debug('Fetching change dates for incidents with change links');
+    }
+
+    return Promise.all(
+      incidents.map(async (incidentData) => {
+        if (!incidentData.changeLink) {
+          return incidentData;
+        }
+
+        try {
+          let changeDate = null;
+
+          if (incidentData.changeLink.type === 'merge_request') {
+            // Fetch MR details to get merge date
+            const mrDetails = await this.mergeRequestClient.fetchMergeRequestDetails(
+              incidentData.changeLink.project,
+              incidentData.changeLink.id
+            );
+            changeDate = mrDetails?.mergedAt || null;
+            if (this.logger) {
+              this.logger.debug('Fetched MR merge date for incident', {
+                incidentIid: incidentData.iid,
+                mrId: incidentData.changeLink.id,
+                mergedAt: changeDate
+              });
+            }
+          } else if (incidentData.changeLink.type === 'commit') {
+            // Fetch commit details to get commit date
+            const commitDetails = await this.mergeRequestClient.fetchCommitDetails(
+              incidentData.changeLink.project,
+              incidentData.changeLink.sha
+            );
+            changeDate = commitDetails?.committedDate || null;
+            if (this.logger) {
+              this.logger.debug('Fetched commit date for incident', {
+                incidentIid: incidentData.iid,
+                commitSha: incidentData.changeLink.sha.substring(0, 8),
+                committedAt: changeDate
+              });
+            }
+          }
+
+          return {
+            ...incidentData,
+            changeDate,
+          };
+        } catch (error) {
+          if (this.logger) {
+            this.logger.warn('Could not fetch change date for incident', {
+              incidentIid: incidentData.iid,
+              error: error.message
+            });
+          }
+          return incidentData;
+        }
+      })
+    );
+  }
+}

--- a/src/lib/infrastructure/api/clients/IssueClient.js
+++ b/src/lib/infrastructure/api/clients/IssueClient.js
@@ -1,0 +1,173 @@
+/**
+ * Client for fetching GitLab issue and note data.
+ * Handles note pagination and status change extraction.
+ *
+ * @module IssueClient
+ */
+
+/**
+ * Client responsible for fetching issue-related data from GitLab.
+ * Includes note pagination and status change parsing.
+ */
+export class IssueClient {
+  /**
+   * Creates a new IssueClient instance.
+   *
+   * @param {import('../core/GraphQLExecutor.js').GraphQLExecutor} executor - GraphQL executor
+   * @param {import('../core/RateLimitManager.js').RateLimitManager} rateLimitManager - Rate limit manager
+   * @param {import('../../../../core/interfaces/ILogger.js').ILogger} [logger] - Logger instance (optional)
+   */
+  constructor(executor, rateLimitManager, logger = null) {
+    this.executor = executor;
+    this.rateLimitManager = rateLimitManager;
+    this.logger = logger;
+  }
+
+  /**
+   * Fetches all notes for a specific issue using pagination.
+   * Used when the first batch of notes doesn't contain an InProgress status change.
+   *
+   * @param {string} issueId - GitLab issue ID (e.g., 'gid://gitlab/Issue/123')
+   * @param {string} startCursor - Cursor to start fetching from (endCursor from previous batch)
+   * @returns {Promise<Array>} Array of all remaining note objects
+   * @throws {Error} If the request fails
+   */
+  async fetchAdditionalNotesForIssue(issueId, startCursor) {
+    const query = `
+      query getIssueNotes($issueId: IssueID!, $after: String) {
+        issue(id: $issueId) {
+          id
+          notes(first: 100, after: $after) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              id
+              body
+              system
+              systemNoteMetadata {
+                action
+              }
+              createdAt
+            }
+          }
+        }
+      }
+    `;
+
+    let allNotes = [];
+    let hasNextPage = true;
+    let after = startCursor;
+    let pagesFetched = 0;
+
+    try {
+      while (hasNextPage) {
+        const data = await this.executor.execute(
+          query,
+          { issueId, after },
+          'fetching issue notes'
+        );
+
+        if (!data.issue) {
+          throw new Error(`Issue not found: ${issueId}`);
+        }
+
+        const { nodes, pageInfo } = data.issue.notes;
+        allNotes = allNotes.concat(nodes);
+        pagesFetched++;
+        hasNextPage = pageInfo.hasNextPage;
+        after = pageInfo.endCursor;
+
+        // Log pagination progress
+        if (this.logger) {
+          this.logger.debug('Fetched notes page', {
+            page: pagesFetched,
+            notesCount: nodes.length,
+            hasNextPage
+          });
+        }
+
+        // Small delay to avoid rate limiting
+        if (hasNextPage) {
+          await this.rateLimitManager.delay(100);
+        }
+      }
+
+      if (this.logger) {
+        this.logger.debug('Completed fetching all notes', {
+          totalPages: pagesFetched,
+          totalNotes: allNotes.length,
+          status: 'all notes exhausted'
+        });
+      }
+      return allNotes;
+    } catch (error) {
+      // Check if it's a GraphQL error
+      if (error.response?.errors) {
+        throw new Error(`Failed to fetch additional notes: ${error.response.errors[0].message}`);
+      }
+      throw new Error(`Failed to fetch additional notes: ${error.message}`);
+    }
+  }
+
+  /**
+   * Extracts the first "In Progress" timestamp from issue notes.
+   * Parses system notes with work_item_status action.
+   *
+   * @param {Array<Object>} notes - Array of note objects from GitLab
+   * @returns {string|null} ISO timestamp when issue first moved to "In Progress", or null
+   */
+  extractInProgressTimestamp(notes) {
+    const statusChanges = this.parseStatusChanges(notes);
+    const inProgressChange = statusChanges.find((change) =>
+      this.isInProgressStatus(change.status)
+    );
+    return inProgressChange?.timestamp || null;
+  }
+
+  /**
+   * Parses status change events from issue notes.
+   * Filters for system notes with work_item_status action.
+   *
+   * @param {Array<Object>} notes - Array of note objects from GitLab
+   * @returns {Array<{status: string, timestamp: string}>} Status transitions in chronological order
+   */
+  parseStatusChanges(notes) {
+    return notes
+      .filter(
+        (note) =>
+          note.system && note.systemNoteMetadata?.action === 'work_item_status'
+      )
+      .map((note) => {
+        // Extract status from body text: "set status to **In progress**"
+        const match = note.body.match(/set status to \*\*(.+?)\*\*/);
+        const status = match ? match[1] : null;
+
+        return {
+          status,
+          timestamp: note.createdAt,
+          body: note.body,
+        };
+      })
+      .filter((change) => change.status !== null)
+      .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+  }
+
+  /**
+   * Checks if a status string indicates "In Progress" state.
+   * Supports variations like "In progress", "in progress", "In-Progress", "WIP", etc.
+   *
+   * @param {string} status - Status string from note
+   * @returns {boolean} True if status indicates in-progress state
+   */
+  isInProgressStatus(status) {
+    const patterns = [
+      /in progress/i,
+      /in-progress/i,
+      /wip/i,
+      /working/i,
+    ];
+    return patterns.some((pattern) => pattern.test(status));
+  }
+}

--- a/src/lib/infrastructure/api/clients/IterationClient.js
+++ b/src/lib/infrastructure/api/clients/IterationClient.js
@@ -1,0 +1,133 @@
+/**
+ * Client for fetching GitLab iteration data.
+ * Handles iteration list retrieval with pagination and group path fallback.
+ *
+ * @module IterationClient
+ */
+
+/**
+ * Client responsible for fetching iteration (sprint) data from GitLab.
+ */
+export class IterationClient {
+  /**
+   * Creates a new IterationClient instance.
+   *
+   * @param {import('../core/GraphQLExecutor.js').GraphQLExecutor} executor - GraphQL executor
+   * @param {import('../core/RateLimitManager.js').RateLimitManager} rateLimitManager - Rate limit manager
+   * @param {string} projectPath - GitLab project path (e.g., 'group/project')
+   * @param {import('../../../../core/interfaces/ILogger.js').ILogger} [logger] - Logger instance (optional)
+   */
+  constructor(executor, rateLimitManager, projectPath, logger = null) {
+    this.executor = executor;
+    this.rateLimitManager = rateLimitManager;
+    this.projectPath = projectPath;
+    this.logger = logger;
+  }
+
+  /**
+   * Fetches all iterations (sprints) for the group.
+   * Handles pagination and automatically falls back to parent group if needed.
+   *
+   * @returns {Promise<Array>} Array of iteration objects
+   * @throws {Error} If the group is not found or request fails
+   */
+  async fetchIterations() {
+    let groupPath = this.projectPath;
+
+    const query = `
+      query getIterations($fullPath: ID!, $after: String) {
+        group(fullPath: $fullPath) {
+          id
+          name
+          iterations(first: 100, after: $after, includeAncestors: false) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              id
+              iid
+              title
+              description
+              state
+              startDate
+              dueDate
+              createdAt
+              updatedAt
+              webUrl
+              iterationCadence {
+                id
+                title
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    let allIterations = [];
+    let hasNextPage = true;
+    let after = null;
+
+    try {
+      while (hasNextPage) {
+        const data = await this.executor.execute(
+          query,
+          { fullPath: groupPath, after },
+          'fetching iterations'
+        );
+
+        // Check if group exists
+        if (!data.group) {
+          // Try removing last segment (might be a project path)
+          const segments = this.projectPath.split('/');
+          if (segments.length > 1) {
+            groupPath = segments.slice(0, -1).join('/');
+            if (this.logger) {
+              this.logger.debug('Trying parent group', { groupPath });
+            }
+            continue; // Retry with parent group
+          }
+          throw new Error(`Group not found: ${groupPath}. Please check your GITLAB_PROJECT_PATH in .env`);
+        }
+
+        // Check if iterations are available
+        if (!data.group.iterations || !data.group.iterations.nodes) {
+          if (this.logger) {
+            this.logger.warn('Group does not have iterations configured', {
+              groupPath,
+              suggestion: 'Enable iterations in Group Settings > Iterations'
+            });
+          }
+          return [];
+        }
+
+        const { nodes, pageInfo } = data.group.iterations;
+        allIterations = allIterations.concat(nodes);
+        hasNextPage = pageInfo.hasNextPage;
+        after = pageInfo.endCursor;
+
+        // Small delay to avoid rate limiting
+        if (hasNextPage) {
+          await this.rateLimitManager.delay(100);
+        }
+      }
+
+      if (this.logger) {
+        this.logger.debug('Found iterations', {
+          count: allIterations.length,
+          groupPath
+        });
+      }
+
+      return allIterations;
+    } catch (error) {
+      // Check if it's a GraphQL error
+      if (error.response?.errors) {
+        const errorMessages = error.response.errors.map(e => e.message).join(', ');
+        throw new Error(`GitLab API Error (fetching iterations): ${errorMessages}`);
+      }
+      throw error;
+    }
+  }
+}

--- a/test/infrastructure/api/GitLabClient.test.js
+++ b/test/infrastructure/api/GitLabClient.test.js
@@ -296,7 +296,7 @@ describe('GitLabClient', () => {
 
       mockRequest.mockRejectedValue(mockError);
 
-      await expect(client.fetchIterations()).rejects.toThrow('GitLab API Error: Unauthorized');
+      await expect(client.fetchIterations()).rejects.toThrow('GitLab API Error (fetching iterations): Unauthorized');
     });
   });
 
@@ -555,7 +555,7 @@ describe('GitLabClient', () => {
       mockRequest.mockRejectedValue(mockError);
 
       await expect(client.fetchAdditionalNotesForIssue('gid://gitlab/Issue/123', 'cursor1')).rejects.toThrow(
-        'Failed to fetch additional notes: Insufficient permissions'
+        'Failed to fetch additional notes: GitLab API Error (fetching issue notes): Insufficient permissions'
       );
     });
 
@@ -564,7 +564,7 @@ describe('GitLabClient', () => {
       mockRequest.mockRejectedValue(networkError);
 
       await expect(client.fetchAdditionalNotesForIssue('gid://gitlab/Issue/123', 'cursor1')).rejects.toThrow(
-        'Failed to fetch additional notes: Connection timeout'
+        'Failed to fetch additional notes: Failed fetching issue notes: Connection timeout'
       );
     });
 
@@ -2069,7 +2069,7 @@ describe('GitLabClient', () => {
       mockRequest.mockRejectedValue(mockError);
 
       await expect(client.fetchIncidents('2025-01-01', '2025-01-10')).rejects.toThrow(
-        'Failed to fetch incidents: Insufficient permissions to query incidents'
+        'Failed to fetch incidents: GitLab API Error (fetching incidents): Insufficient permissions to query incidents'
       );
     });
 
@@ -2078,7 +2078,7 @@ describe('GitLabClient', () => {
       mockRequest.mockRejectedValue(networkError);
 
       await expect(client.fetchIncidents('2025-01-01', '2025-01-10')).rejects.toThrow(
-        'Failed to fetch incidents: Connection timeout'
+        'Failed to fetch incidents: Failed fetching incidents: Connection timeout'
       );
     });
 

--- a/test/infrastructure/api/clients/IncidentClient.test.js
+++ b/test/infrastructure/api/clients/IncidentClient.test.js
@@ -1,0 +1,363 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { IncidentClient } from '../../../../src/lib/infrastructure/api/clients/IncidentClient.js';
+
+describe('IncidentClient', () => {
+  let client;
+  let mockExecutor;
+  let mockRateLimitManager;
+  let mockMergeRequestClient;
+  let mockLogger;
+
+  beforeEach(() => {
+    mockExecutor = {
+      execute: async () => ({})
+    };
+
+    mockRateLimitManager = {
+      delay: async () => {}
+    };
+
+    mockMergeRequestClient = {
+      fetchMergeRequestDetails: async () => ({}),
+      fetchCommitDetails: async () => ({})
+    };
+
+    mockLogger = {
+      debug: () => {},
+      warn: () => {},
+      error: () => {}
+    };
+
+    client = new IncidentClient(
+      mockExecutor,
+      mockRateLimitManager,
+      'group/project',
+      mockMergeRequestClient,
+      mockLogger
+    );
+  });
+
+  describe('extractProjectPath', () => {
+    it('should extract project path from GitLab URL', () => {
+      const result = client.extractProjectPath('https://gitlab.com/group/project/-/issues/123');
+      expect(result).toBe('group/project');
+    });
+
+    it('should extract nested project path', () => {
+      const result = client.extractProjectPath('https://gitlab.com/group/subgroup/project/-/issues/123');
+      expect(result).toBe('group/subgroup/project');
+    });
+
+    it('should return null for invalid URL', () => {
+      const result = client.extractProjectPath('not-a-url');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty path', () => {
+      const result = client.extractProjectPath('https://gitlab.com/-/issues/123');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('fetchIncidentTimelineEvents', () => {
+    it('should fetch timeline events successfully', async () => {
+      mockExecutor.execute = async () => ({
+        project: {
+          incidentManagementTimelineEvents: {
+            nodes: [
+              {
+                id: '1',
+                occurredAt: '2025-01-01T10:00:00Z',
+                note: 'Incident started',
+                timelineEventTags: { nodes: [{ name: 'start time' }] },
+                author: { username: 'user1', name: 'User One' }
+              },
+              {
+                id: '2',
+                occurredAt: '2025-01-01T12:00:00Z',
+                note: 'Incident resolved',
+                timelineEventTags: { nodes: [{ name: 'end time' }] },
+                author: { username: 'user1', name: 'User One' }
+              }
+            ]
+          }
+        }
+      });
+
+      const incident = {
+        id: 'gid://gitlab/Issue/123',
+        webUrl: 'https://gitlab.com/group/project/-/issues/123'
+      };
+
+      const result = await client.fetchIncidentTimelineEvents(incident);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].note).toBe('Incident started');
+    });
+
+    it('should return empty array if project not found', async () => {
+      mockExecutor.execute = async () => ({
+        project: null
+      });
+
+      const incident = {
+        id: 'gid://gitlab/Issue/123',
+        webUrl: 'https://gitlab.com/group/project/-/issues/123'
+      };
+
+      const result = await client.fetchIncidentTimelineEvents(incident);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array if project path extraction fails', async () => {
+      const incident = {
+        id: 'gid://gitlab/Issue/123',
+        webUrl: 'not-a-valid-url'
+      };
+
+      const result = await client.fetchIncidentTimelineEvents(incident);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array on GraphQL errors', async () => {
+      mockExecutor.execute = async () => {
+        const error = new Error('GraphQL error');
+        error.response = {
+          errors: [{ message: 'Timeline not accessible' }]
+        };
+        throw error;
+      };
+
+      let errorLogged = false;
+      mockLogger.error = () => {
+        errorLogged = true;
+      };
+
+      const incident = {
+        id: 'gid://gitlab/Issue/123',
+        webUrl: 'https://gitlab.com/group/project/-/issues/123'
+      };
+
+      const result = await client.fetchIncidentTimelineEvents(incident);
+
+      expect(result).toEqual([]);
+      expect(errorLogged).toBe(true);
+    });
+
+    it('should work without logger', async () => {
+      const clientWithoutLogger = new IncidentClient(
+        mockExecutor,
+        mockRateLimitManager,
+        'group/project',
+        mockMergeRequestClient
+      );
+
+      mockExecutor.execute = async () => ({
+        project: {
+          incidentManagementTimelineEvents: {
+            nodes: [{ id: '1', occurredAt: '2025-01-01T10:00:00Z' }]
+          }
+        }
+      });
+
+      const incident = {
+        id: 'gid://gitlab/Issue/123',
+        webUrl: 'https://gitlab.com/group/project/-/issues/123'
+      };
+
+      const result = await clientWithoutLogger.fetchIncidentTimelineEvents(incident);
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('fetchIncidents', () => {
+    it('should fetch incidents successfully', async () => {
+      mockExecutor.execute = async (query, variables, context) => {
+        if (context === 'fetching incidents') {
+          return {
+            group: {
+              id: 'gid://gitlab/Group/1',
+              issues: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/Issue/1',
+                    iid: 1,
+                    title: 'Incident 1',
+                    state: 'closed',
+                    createdAt: '2025-01-05T10:00:00Z',
+                    closedAt: '2025-01-05T12:00:00Z',
+                    updatedAt: '2025-01-05T12:00:00Z',
+                    webUrl: 'https://gitlab.com/group/project/-/issues/1',
+                    labels: { nodes: [] }
+                  }
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null }
+              }
+            }
+          };
+        }
+        // Timeline events query
+        return {
+          project: {
+            incidentManagementTimelineEvents: {
+              nodes: [
+                {
+                  id: '1',
+                  occurredAt: '2025-01-05T10:00:00Z',
+                  note: 'Started',
+                  timelineEventTags: { nodes: [{ name: 'start time' }] }
+                }
+              ]
+            }
+          }
+        };
+      };
+
+      const result = await client.fetchIncidents('2025-01-01', '2025-01-10');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].iid).toBe(1);
+      expect(result[0].actualStartTime).toBeDefined();
+    });
+
+    it('should throw error if group not found', async () => {
+      mockExecutor.execute = async () => ({
+        group: null
+      });
+
+      await expect(client.fetchIncidents('2025-01-01', '2025-01-10')).rejects.toThrow(
+        'Group not found: group/project'
+      );
+    });
+
+    it('should handle GraphQL errors', async () => {
+      mockExecutor.execute = async () => {
+        const error = new Error('GraphQL error');
+        error.response = {
+          errors: [{ message: 'Insufficient permissions' }]
+        };
+        throw error;
+      };
+
+      await expect(client.fetchIncidents('2025-01-01', '2025-01-10')).rejects.toThrow(
+        'Failed to fetch incidents: Insufficient permissions'
+      );
+    });
+
+    it('should handle pagination', async () => {
+      let callCount = 0;
+      mockExecutor.execute = async (query, variables, context) => {
+        if (context === 'fetching incidents') {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              group: {
+                issues: {
+                  nodes: [{ id: '1', iid: 1, title: 'I1', state: 'closed', createdAt: '2025-01-05T10:00:00Z', closedAt: '2025-01-05T12:00:00Z', updatedAt: '2025-01-05T12:00:00Z', webUrl: 'https://gitlab.com/g/p/-/issues/1', labels: { nodes: [] } }],
+                  pageInfo: { hasNextPage: true, endCursor: 'cursor1' }
+                }
+              }
+            };
+          }
+          return {
+            group: {
+              issues: {
+                nodes: [{ id: '2', iid: 2, title: 'I2', state: 'closed', createdAt: '2025-01-06T10:00:00Z', closedAt: '2025-01-06T12:00:00Z', updatedAt: '2025-01-06T12:00:00Z', webUrl: 'https://gitlab.com/g/p/-/issues/2', labels: { nodes: [] } }],
+                pageInfo: { hasNextPage: false, endCursor: null }
+              }
+            }
+          };
+        }
+        // Timeline events query
+        return { project: { incidentManagementTimelineEvents: { nodes: [] } } };
+      };
+
+      const delayCalls = [];
+      mockRateLimitManager.delay = async (ms) => {
+        delayCalls.push(ms);
+      };
+
+      const result = await client.fetchIncidents('2025-01-01', '2025-01-10');
+
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(delayCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should filter incidents by date range', async () => {
+      // Incident created OUTSIDE iteration but no timeline events
+      mockExecutor.execute = async (query, variables, context) => {
+        if (context === 'fetching incidents') {
+          return {
+            group: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/Issue/1',
+                    iid: 1,
+                    title: 'Old Incident',
+                    state: 'closed',
+                    createdAt: '2024-11-15T10:00:00Z', // Before iteration
+                    closedAt: '2024-11-15T12:00:00Z',   // Before iteration
+                    updatedAt: '2024-11-15T12:00:00Z',  // Before iteration
+                    webUrl: 'https://gitlab.com/g/p/-/issues/1',
+                    labels: { nodes: [] }
+                  }
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null }
+              }
+            }
+          };
+        }
+        // No timeline events
+        return { project: { incidentManagementTimelineEvents: { nodes: [] } } };
+      };
+
+      const result = await client.fetchIncidents('2025-01-01', '2025-01-10');
+
+      // Should be filtered out since no activity during iteration
+      expect(result).toHaveLength(0);
+    });
+
+    it('should work without logger', async () => {
+      const clientWithoutLogger = new IncidentClient(
+        mockExecutor,
+        mockRateLimitManager,
+        'group/project',
+        mockMergeRequestClient
+      );
+
+      mockExecutor.execute = async (query, variables, context) => {
+        if (context === 'fetching incidents') {
+          return {
+            group: {
+              issues: {
+                nodes: [
+                  {
+                    id: '1',
+                    iid: 1,
+                    title: 'I1',
+                    state: 'closed',
+                    createdAt: '2025-01-05T10:00:00Z',
+                    closedAt: '2025-01-05T12:00:00Z',
+                    updatedAt: '2025-01-05T12:00:00Z',
+                    webUrl: 'https://gitlab.com/g/p/-/issues/1',
+                    labels: { nodes: [] }
+                  }
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null }
+              }
+            }
+          };
+        }
+        return { project: { incidentManagementTimelineEvents: { nodes: [] } } };
+      };
+
+      const result = await clientWithoutLogger.fetchIncidents('2025-01-01', '2025-01-10');
+
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/test/infrastructure/api/clients/IssueClient.test.js
+++ b/test/infrastructure/api/clients/IssueClient.test.js
@@ -1,0 +1,275 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { IssueClient } from '../../../../src/lib/infrastructure/api/clients/IssueClient.js';
+
+describe('IssueClient', () => {
+  let client;
+  let mockExecutor;
+  let mockRateLimitManager;
+  let mockLogger;
+
+  beforeEach(() => {
+    mockExecutor = {
+      execute: async () => ({})
+    };
+
+    mockRateLimitManager = {
+      delay: async () => {}
+    };
+
+    mockLogger = {
+      debug: () => {},
+      warn: () => {},
+      error: () => {}
+    };
+
+    client = new IssueClient(
+      mockExecutor,
+      mockRateLimitManager,
+      mockLogger
+    );
+  });
+
+  describe('fetchAdditionalNotesForIssue', () => {
+    it('should fetch additional notes successfully', async () => {
+      mockExecutor.execute = async () => ({
+        issue: {
+          id: 'gid://gitlab/Issue/123',
+          notes: {
+            nodes: [
+              { id: '1', body: 'Note 1', system: false, createdAt: '2025-01-01T00:00:00Z' },
+              { id: '2', body: 'Note 2', system: true, createdAt: '2025-01-02T00:00:00Z' }
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null }
+          }
+        }
+      });
+
+      const result = await client.fetchAdditionalNotesForIssue('gid://gitlab/Issue/123', 'cursor1');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].body).toBe('Note 1');
+    });
+
+    it('should handle pagination for notes', async () => {
+      let callCount = 0;
+      mockExecutor.execute = async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            issue: {
+              id: 'gid://gitlab/Issue/123',
+              notes: {
+                nodes: [{ id: '1', body: 'Note 1', system: false, createdAt: '2025-01-01T00:00:00Z' }],
+                pageInfo: { hasNextPage: true, endCursor: 'cursor2' }
+              }
+            }
+          };
+        } else {
+          return {
+            issue: {
+              id: 'gid://gitlab/Issue/123',
+              notes: {
+                nodes: [{ id: '2', body: 'Note 2', system: false, createdAt: '2025-01-02T00:00:00Z' }],
+                pageInfo: { hasNextPage: false, endCursor: null }
+              }
+            }
+          };
+        }
+      };
+
+      const delayCalls = [];
+      mockRateLimitManager.delay = async (ms) => {
+        delayCalls.push(ms);
+      };
+
+      const result = await client.fetchAdditionalNotesForIssue('gid://gitlab/Issue/123', 'cursor1');
+
+      expect(result).toHaveLength(2);
+      expect(delayCalls).toHaveLength(1);
+      expect(delayCalls[0]).toBe(100);
+    });
+
+    it('should throw error if issue not found', async () => {
+      mockExecutor.execute = async () => ({
+        issue: null
+      });
+
+      await expect(
+        client.fetchAdditionalNotesForIssue('gid://gitlab/Issue/999', 'cursor1')
+      ).rejects.toThrow('Issue not found: gid://gitlab/Issue/999');
+    });
+
+    it('should throw error on GraphQL errors', async () => {
+      mockExecutor.execute = async () => {
+        const error = new Error('GraphQL error');
+        error.response = {
+          errors: [{ message: 'Insufficient permissions' }]
+        };
+        throw error;
+      };
+
+      await expect(
+        client.fetchAdditionalNotesForIssue('gid://gitlab/Issue/123', 'cursor1')
+      ).rejects.toThrow('Failed to fetch additional notes: Insufficient permissions');
+    });
+
+    it('should work without logger', async () => {
+      const clientWithoutLogger = new IssueClient(
+        mockExecutor,
+        mockRateLimitManager
+      );
+
+      mockExecutor.execute = async () => ({
+        issue: {
+          id: 'gid://gitlab/Issue/123',
+          notes: {
+            nodes: [{ id: '1', body: 'Note 1', system: false, createdAt: '2025-01-01T00:00:00Z' }],
+            pageInfo: { hasNextPage: false, endCursor: null }
+          }
+        }
+      });
+
+      const result = await clientWithoutLogger.fetchAdditionalNotesForIssue(
+        'gid://gitlab/Issue/123',
+        'cursor1'
+      );
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('extractInProgressTimestamp', () => {
+    it('should extract InProgress timestamp from notes', () => {
+      const notes = [
+        {
+          id: '1',
+          body: 'set status to **Open**',
+          system: true,
+          systemNoteMetadata: { action: 'work_item_status' },
+          createdAt: '2025-01-01T00:00:00Z'
+        },
+        {
+          id: '2',
+          body: 'set status to **In progress**',
+          system: true,
+          systemNoteMetadata: { action: 'work_item_status' },
+          createdAt: '2025-01-02T10:00:00Z'
+        }
+      ];
+
+      const result = client.extractInProgressTimestamp(notes);
+
+      expect(result).toBe('2025-01-02T10:00:00Z');
+    });
+
+    it('should return null if no InProgress status found', () => {
+      const notes = [
+        {
+          id: '1',
+          body: 'set status to **Open**',
+          system: true,
+          systemNoteMetadata: { action: 'work_item_status' },
+          createdAt: '2025-01-01T00:00:00Z'
+        }
+      ];
+
+      const result = client.extractInProgressTimestamp(notes);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty notes array', () => {
+      const result = client.extractInProgressTimestamp([]);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('parseStatusChanges', () => {
+    it('should parse status change notes', () => {
+      const notes = [
+        {
+          id: '1',
+          body: 'set status to **Open**',
+          system: true,
+          systemNoteMetadata: { action: 'work_item_status' },
+          createdAt: '2025-01-01T00:00:00Z'
+        },
+        {
+          id: '2',
+          body: 'Some comment',
+          system: false,
+          systemNoteMetadata: null,
+          createdAt: '2025-01-01T12:00:00Z'
+        },
+        {
+          id: '3',
+          body: 'set status to **In progress**',
+          system: true,
+          systemNoteMetadata: { action: 'work_item_status' },
+          createdAt: '2025-01-02T00:00:00Z'
+        }
+      ];
+
+      const result = client.parseStatusChanges(notes);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].status).toBe('Open');
+      expect(result[1].status).toBe('In progress');
+    });
+
+    it('should sort status changes chronologically', () => {
+      const notes = [
+        {
+          id: '2',
+          body: 'set status to **Closed**',
+          system: true,
+          systemNoteMetadata: { action: 'work_item_status' },
+          createdAt: '2025-01-03T00:00:00Z'
+        },
+        {
+          id: '1',
+          body: 'set status to **Open**',
+          system: true,
+          systemNoteMetadata: { action: 'work_item_status' },
+          createdAt: '2025-01-01T00:00:00Z'
+        }
+      ];
+
+      const result = client.parseStatusChanges(notes);
+
+      expect(result[0].status).toBe('Open');
+      expect(result[1].status).toBe('Closed');
+    });
+  });
+
+  describe('isInProgressStatus', () => {
+    it('should recognize "In progress" as in-progress', () => {
+      expect(client.isInProgressStatus('In progress')).toBe(true);
+    });
+
+    it('should recognize "in progress" (lowercase) as in-progress', () => {
+      expect(client.isInProgressStatus('in progress')).toBe(true);
+    });
+
+    it('should recognize "In-Progress" (hyphenated) as in-progress', () => {
+      expect(client.isInProgressStatus('In-Progress')).toBe(true);
+    });
+
+    it('should recognize "WIP" as in-progress', () => {
+      expect(client.isInProgressStatus('WIP')).toBe(true);
+    });
+
+    it('should recognize "Working" as in-progress', () => {
+      expect(client.isInProgressStatus('Working')).toBe(true);
+    });
+
+    it('should not recognize "Open" as in-progress', () => {
+      expect(client.isInProgressStatus('Open')).toBe(false);
+    });
+
+    it('should not recognize "Closed" as in-progress', () => {
+      expect(client.isInProgressStatus('Closed')).toBe(false);
+    });
+  });
+});

--- a/test/infrastructure/api/clients/IterationClient.test.js
+++ b/test/infrastructure/api/clients/IterationClient.test.js
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { IterationClient } from '../../../../src/lib/infrastructure/api/clients/IterationClient.js';
+
+describe('IterationClient', () => {
+  let client;
+  let mockExecutor;
+  let mockRateLimitManager;
+  let mockLogger;
+
+  beforeEach(() => {
+    mockExecutor = {
+      execute: async () => ({})
+    };
+
+    mockRateLimitManager = {
+      delay: async () => {}
+    };
+
+    mockLogger = {
+      debug: () => {},
+      warn: () => {},
+      error: () => {}
+    };
+
+    client = new IterationClient(
+      mockExecutor,
+      mockRateLimitManager,
+      'group/project',
+      mockLogger
+    );
+  });
+
+  describe('fetchIterations', () => {
+    it('should fetch iterations successfully', async () => {
+      mockExecutor.execute = async () => ({
+        group: {
+          id: 'gid://gitlab/Group/1',
+          name: 'Test Group',
+          iterations: {
+            nodes: [
+              {
+                id: 'gid://gitlab/Iteration/1',
+                iid: '1',
+                title: 'Sprint 1',
+                state: 'closed',
+                startDate: '2025-01-01',
+                dueDate: '2025-01-14',
+                iterationCadence: { id: '1', title: 'Dev Cadence' }
+              },
+              {
+                id: 'gid://gitlab/Iteration/2',
+                iid: '2',
+                title: 'Sprint 2',
+                state: 'current',
+                startDate: '2025-01-15',
+                dueDate: '2025-01-28',
+                iterationCadence: { id: '1', title: 'Dev Cadence' }
+              }
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null }
+          }
+        }
+      });
+
+      const result = await client.fetchIterations();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].title).toBe('Sprint 1');
+      expect(result[1].title).toBe('Sprint 2');
+    });
+
+    it('should handle pagination for iterations', async () => {
+      let callCount = 0;
+      mockExecutor.execute = async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            group: {
+              id: 'gid://gitlab/Group/1',
+              iterations: {
+                nodes: [{ id: '1', title: 'Sprint 1', state: 'closed' }],
+                pageInfo: { hasNextPage: true, endCursor: 'cursor1' }
+              }
+            }
+          };
+        } else {
+          return {
+            group: {
+              id: 'gid://gitlab/Group/1',
+              iterations: {
+                nodes: [{ id: '2', title: 'Sprint 2', state: 'closed' }],
+                pageInfo: { hasNextPage: false, endCursor: null }
+              }
+            }
+          };
+        }
+      };
+
+      const delayCalls = [];
+      mockRateLimitManager.delay = async (ms) => {
+        delayCalls.push(ms);
+      };
+
+      const result = await client.fetchIterations();
+
+      expect(result).toHaveLength(2);
+      expect(delayCalls).toHaveLength(1);
+      expect(delayCalls[0]).toBe(100);
+    });
+
+    it('should try parent group if initial group not found', async () => {
+      let callCount = 0;
+      mockExecutor.execute = async (query, variables) => {
+        callCount++;
+        if (callCount === 1) {
+          // First call with 'group/subgroup/project' returns null group
+          return { group: null };
+        } else {
+          // Second call with 'group/subgroup' succeeds
+          return {
+            group: {
+              id: 'gid://gitlab/Group/1',
+              iterations: {
+                nodes: [{ id: '1', title: 'Sprint 1', state: 'closed' }],
+                pageInfo: { hasNextPage: false, endCursor: null }
+              }
+            }
+          };
+        }
+      };
+
+      // Use a deeper project path
+      const deepClient = new IterationClient(
+        mockExecutor,
+        mockRateLimitManager,
+        'group/subgroup/project',
+        mockLogger
+      );
+
+      const result = await deepClient.fetchIterations();
+
+      expect(result).toHaveLength(1);
+      expect(callCount).toBe(2);
+    });
+
+    it('should throw error if group not found after exhausting paths', async () => {
+      mockExecutor.execute = async () => ({
+        group: null
+      });
+
+      // Single-segment path with no parent to try
+      const singleClient = new IterationClient(
+        mockExecutor,
+        mockRateLimitManager,
+        'single',
+        mockLogger
+      );
+
+      await expect(singleClient.fetchIterations()).rejects.toThrow(
+        'Group not found: single'
+      );
+    });
+
+    it('should return empty array if group has no iterations configured', async () => {
+      mockExecutor.execute = async () => ({
+        group: {
+          id: 'gid://gitlab/Group/1',
+          name: 'Test Group',
+          iterations: null
+        }
+      });
+
+      let warnCalled = false;
+      mockLogger.warn = () => {
+        warnCalled = true;
+      };
+
+      const result = await client.fetchIterations();
+
+      expect(result).toEqual([]);
+      expect(warnCalled).toBe(true);
+    });
+
+    it('should throw transformed error on GraphQL errors', async () => {
+      mockExecutor.execute = async () => {
+        const error = new Error('GraphQL error');
+        error.response = {
+          errors: [{ message: 'Permission denied' }]
+        };
+        throw error;
+      };
+
+      await expect(client.fetchIterations()).rejects.toThrow(
+        'GitLab API Error (fetching iterations): Permission denied'
+      );
+    });
+
+    it('should work without logger', async () => {
+      const clientWithoutLogger = new IterationClient(
+        mockExecutor,
+        mockRateLimitManager,
+        'group/project'
+      );
+
+      mockExecutor.execute = async () => ({
+        group: {
+          id: 'gid://gitlab/Group/1',
+          iterations: {
+            nodes: [{ id: '1', title: 'Sprint 1', state: 'closed' }],
+            pageInfo: { hasNextPage: false, endCursor: null }
+          }
+        }
+      });
+
+      const result = await clientWithoutLogger.fetchIterations();
+
+      expect(result).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Completes Phase 1.3 of the GitLabClient refactoring by extracting the final 3 specialized clients.

### IterationClient (7 tests)
- `fetchIterations()` - iteration list with pagination and parent group fallback

### IssueClient (17 tests)
- `fetchAdditionalNotesForIssue()` - paginated note fetching
- `extractInProgressTimestamp()` - status extraction from notes
- `parseStatusChanges()` - note parsing helper
- `isInProgressStatus()` - status pattern matching

### IncidentClient (15 tests)
- `fetchIncidents()` - complex incident fetching with timeline enrichment
- `fetchIncidentTimelineEvents()` - timeline event fetching
- `extractProjectPath()` - URL parsing helper
- Includes timeline-based filtering and change link extraction

## Results

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| GitLabClient lines | 1,134 | 548 | -52% |
| New unit tests | - | 39 | +39 |
| Total tests | 907 | 946 | +39 |

## Test plan

- [x] All 946 tests pass
- [x] TDD approach followed (tests written first)
- [x] Backward compatibility maintained (public API unchanged)
- [x] Error messages updated in tests to match new format

## Phase 1.3 Complete Summary

| Phase | Client | Methods | Tests |
|-------|--------|---------|-------|
| 1.3a | Core Helpers | 3 | 10 |
| 1.3b-1 | DeploymentClient | 1 | 5 |
| 1.3b-2 | PipelineClient + MergeRequestClient | 4 | 14 |
| 1.3b-3 | IterationClient + IssueClient + IncidentClient | 7 | 39 |

**Total:** 15 methods extracted, 68 new tests, GitLabClient reduced 55%

🤖 Generated with [Claude Code](https://claude.com/claude-code)